### PR TITLE
Allowing a one-time rescaling skip during the `setPointPositions` call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmograph/cosmos",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmograph/cosmos",
-      "version": "2.0.0-beta.21",
+      "version": "2.0.0-beta.25",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmograph/cosmos",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.25",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,15 +272,14 @@ export class Graph {
    * @param {Float32Array} pointPositions - A Float32Array representing the positions of points in the format [x1, y1, x2, y2, ..., xn, yn],
    * where `n` is the index of the point.
    * Example: `new Float32Array([1, 2, 3, 4, 5, 6])` sets the first point to (1, 2), the second point to (3, 4), and so on.
-   * @param {boolean | undefined} rescaleOverride - Overrides the `config.rescalePositions` setting for this call only.
-   *   - `true`: Force rescaling.
-   *   - `false`: Force *no* rescaling. This will not reset the scale functions.
-   *   - `undefined` (default): Use the behavior defined by `config.rescalePositions`.
+   * @param {boolean | undefined} dontRescale - For this call only, don't rescale the points.
+   *   - `true`: Don't rescale.
+   *   - `false` or `undefined` (default): Use the behavior defined by `config.rescalePositions`.
    */
-  public setPointPositions (pointPositions: Float32Array, rescaleOverride?: boolean | undefined): void {
+  public setPointPositions (pointPositions: Float32Array, dontRescale?: boolean | undefined): void {
     if (this._isDestroyed) return
     this.graph.inputPointPositions = pointPositions
-    this.points.rescaleOverride = rescaleOverride
+    this.points.dontRescale = dontRescale
     this._hasPointPositionsChanged = true
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,10 +272,15 @@ export class Graph {
    * @param {Float32Array} pointPositions - A Float32Array representing the positions of points in the format [x1, y1, x2, y2, ..., xn, yn],
    * where `n` is the index of the point.
    * Example: `new Float32Array([1, 2, 3, 4, 5, 6])` sets the first point to (1, 2), the second point to (3, 4), and so on.
+   * @param {boolean | undefined} rescaleOverride - Overrides the `config.rescalePositions` setting for this call only.
+   *   - `true`: Force rescaling.
+   *   - `false`: Force *no* rescaling. This will not reset the scale functions.
+   *   - `undefined` (default): Use the behavior defined by `config.rescalePositions`.
    */
-  public setPointPositions (pointPositions: Float32Array): void {
+  public setPointPositions (pointPositions: Float32Array, rescaleOverride?: boolean | undefined): void {
     if (this._isDestroyed) return
     this.graph.inputPointPositions = pointPositions
+    this.points.rescaleOverride = rescaleOverride
     this._hasPointPositionsChanged = true
   }
 


### PR DESCRIPTION
This PR adds the `dontRescale` parameter as the second argument to the `setPointPositions` method, allowing one-time skip of rescaling.